### PR TITLE
Added missing dependency

### DIFF
--- a/application/plantix/pom.xml
+++ b/application/plantix/pom.xml
@@ -43,6 +43,11 @@
 			<artifactId>spring-integration-mqtt</artifactId>
 			<version>6.5.1</version>
 		</dependency>
+        <dependency>
+            <groupId>cn.devicelinks.framework</groupId>
+            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+            <version>1.2.6</version>
+        </dependency>
 
 		<dependency>
 			<groupId>com.mysql</groupId>


### PR DESCRIPTION
To continue progress on [this Trello card](https://trello.com/c/pxLJxpAk/13-configurar-los-distintos-topicos-ulises), it was necessary to include an optional dependency not provided by default in [spring-integration-mqtt](https://docs.spring.io/spring-integration/reference/mqtt.html). This dependency, `org.eclipse.paho.client.mqttv3`, has been added in this branch.